### PR TITLE
fix trigger ordering

### DIFF
--- a/examples/hypercore/credentials.rs
+++ b/examples/hypercore/credentials.rs
@@ -13,7 +13,7 @@ pub struct Credentials {
     #[arg(short, long)]
     keystore: Option<PathBuf>,
     /// Keystore password. Optional, otherwise prompted.
-    #[arg(short, long)]
+    #[arg(long)]
     keystore_password: Option<String>,
     /// Raw private key in hex
     #[arg(short, long)]

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -1579,10 +1579,11 @@ pub enum OrderTypePlacement {
     Limit {
         tif: TimeInForce,
     },
+    #[serde(rename_all = "camelCase")]
     Trigger {
+        is_market: bool,
         #[serde(with = "rust_decimal::serde::str")]
         trigger_px: Decimal,
-        is_market: bool,
         tpsl: TpSl,
     },
 }
@@ -1591,7 +1592,7 @@ pub enum OrderTypePlacement {
 ///
 /// Indicates whether the trigger is a take‑profit (`Tp`) or stop‑loss (`Sl`).
 #[derive(PartialEq, Eq, Deserialize, Serialize, Copy, Clone, Debug)]
-#[serde(rename = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum TpSl {
     Tp,
     Sl,


### PR DESCRIPTION
**Problem**: Trigger orders failed with wrong user because the msgpack serialization didn't match Hyperliquid's expected format, causing signature verification to recover a different address.

**Fix**: Corrected OrderTypePlacement::Trigger field order and added camelCase renames to match the official SDK. Also addressed the Enum serialization issues with camel case.

Also removed the short arg for `keystore_password`. Otherwise it panics because `keystore` and `keystore_password` both resolve to `-k`.