### PR TITLE
Feat: Add NoCross margin mode to PerpUniverseItem

### DIFF
--- a/src/hypercore/mod.rs
+++ b/src/hypercore/mod.rs
@@ -1431,6 +1431,7 @@ struct PerpUniverseItem {
 #[serde(rename_all = "camelCase")]
 pub enum MarginMode {
     StrictIsolated,
+    NoCross,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Running target/debug/examples/list-hip3

markets for xyz
Error: error decoding response body

Caused by:
unknown variant noCross, expected strictIsolated at line 1 column 127