### PR TITLE
feat: add activeAssetCtx WebSocket subscription

### DIFF
--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -632,7 +632,7 @@ impl Client {
     /// Retrieves historical funding rates for a perpetual market.
     ///
     /// Returns funding rate snapshots for the specified coin within the given time range.
-    /// Funding rates are typically applied every 8 hours.
+    /// Hyperliquid pays funding every hour.
     ///
     /// # Parameters
     ///


### PR DESCRIPTION
## Summary

- Add `Subscription::ActiveAssetCtx` for real-time funding rate, mark price, and open interest updates
- Add `AssetContext` struct with helper methods (`annualized_rate`, `is_positive`, `is_negative`)
- Add `decimal_normalized` serde module to match Python SDK's `float_to_wire` behavior for consistent MessagePack hashing
- Fix `FundingRate::annualized_rate()` calculation (Hyperliquid pays hourly, not every 8 hours)

## Changes

| File | Description |
|------|-------------|
| `types/mod.rs` | Add `ActiveAssetCtx` subscription, `AssetContext` struct, fix funding rate docs |
| `utils.rs` | Add `decimal_normalized` serde module |
| `http.rs` | Fix incorrect funding period documentation |

## Test plan

- [x] Verify `ActiveAssetCtx` subscription receives real-time updates
- [x] Verify `decimal_normalized` produces same output as Python SDK's `float_to_wire`
- [x] Verify `annualized_rate()` returns correct value (hourly rate × 24 × 365)