### PR TITLE
feat: add vault transfer (deposit/withdraw) support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,10 @@ name = "vault_details"
 path = "examples/hypercore/vault_details.rs"
 
 [[example]]
+name = "vault_transfer"
+path = "examples/hypercore/vault_transfer.rs"
+
+[[example]]
 name = "user_vault_equities"
 path = "examples/hypercore/user_vault_equities.rs"
 

--- a/examples/hypercore/vault_transfer.rs
+++ b/examples/hypercore/vault_transfer.rs
@@ -1,0 +1,67 @@
+//! Deposit or withdraw USDC from a Hyperliquid vault.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Deposit 100 USDC
+//! cargo run --example vault_transfer -- <VAULT_ADDRESS> deposit 100
+//!
+//! # Withdraw 50 USDC
+//! cargo run --example vault_transfer -- <VAULT_ADDRESS> withdraw 50
+//! ```
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use clap::Parser;
+use hypersdk::{Address, hypercore};
+use rust_decimal::Decimal;
+
+use crate::credentials::Credentials;
+
+mod credentials;
+
+#[derive(Parser, Debug, derive_more::Deref)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[deref]
+    #[command(flatten)]
+    common: Credentials,
+    /// Vault address
+    #[arg(short, long)]
+    vault: Address,
+    /// Operation: "deposit" or "withdraw"
+    #[arg(short, long)]
+    operation: String,
+    /// Amount of USDC
+    #[arg(short, long)]
+    amount: Decimal,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let _ = simple_logger::init_with_level(log::Level::Debug);
+
+    let args = Cli::parse();
+    let signer = args.get()?;
+
+    let client = hypercore::mainnet();
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    match args.operation.as_str() {
+        "deposit" => {
+            client.vault_transfer(&signer, args.vault, args.amount, nonce, true).await?;
+            println!("Deposited ${} into vault {}", args.amount, args.vault);
+        }
+        "withdraw" => {
+            client.vault_transfer(&signer, args.vault, args.amount, nonce, false).await?;
+            println!("Withdrew ${} from vault {}", args.amount, args.vault);
+        }
+        op => anyhow::bail!("unknown operation '{op}', use 'deposit' or 'withdraw'"),
+    }
+
+    Ok(())
+}

--- a/hypecli/Cargo.lock
+++ b/hypecli/Cargo.lock
@@ -2571,7 +2571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "hypersdk"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4362,7 +4362,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5080,7 +5080,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5549,7 +5549,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5629,7 +5629,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6397,7 +6397,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7234,7 +7234,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/hypecli/src/main.rs
+++ b/hypecli/src/main.rs
@@ -8,6 +8,7 @@ mod send;
 mod subscribe;
 mod to_multisig;
 mod utils;
+mod vault;
 
 use account::AccountCmd;
 use balances::BalanceCmd;
@@ -20,6 +21,7 @@ use orders::OrderCmd;
 use send::SendCmd;
 use subscribe::SubscribeCmd;
 use to_multisig::ToMultiSigCmd;
+use vault::VaultCmd;
 
 /// Main CLI structure for hypecli - A command-line interface for Hyperliquid.
 #[derive(Parser)]
@@ -67,6 +69,9 @@ enum Command {
     Subscribe(SubscribeCmd),
     /// Send assets between accounts, DEXes, or subaccounts
     Send(SendCmd),
+    /// Vault deposit and withdrawal commands
+    #[command(subcommand)]
+    Vault(VaultCmd),
 }
 
 impl Command {
@@ -85,6 +90,7 @@ impl Command {
             Self::Order(cmd) => cmd.run().await,
             Self::Subscribe(cmd) => cmd.run().await,
             Self::Send(cmd) => cmd.run().await,
+            Self::Vault(cmd) => cmd.run().await,
         }
     }
 }
@@ -478,6 +484,27 @@ Send From Subaccount:
     --amount 100 \
     --from-subaccount my-sub \
     --destination 0xRECIPIENT
+
+VAULT COMMANDS
+--------------
+
+Deposit USDC into a vault:
+  hypecli vault deposit \
+    --chain mainnet \
+    --private-key <HEX> \
+    --vault <VAULT_ADDRESS> \
+    --amount 100
+
+Withdraw USDC from a vault:
+  hypecli vault withdraw \
+    --chain mainnet \
+    --private-key <HEX> \
+    --vault <VAULT_ADDRESS> \
+    --amount 100
+
+  Arguments:
+    --vault <ADDRESS>    Vault address to deposit into or withdraw from
+    --amount <DECIMAL>   Amount of USDC
 
 SUBSCRIBE COMMANDS (Real-time WebSocket Data)
 ---------------------------------------------

--- a/hypecli/src/vault.rs
+++ b/hypecli/src/vault.rs
@@ -1,0 +1,56 @@
+//! Vault transfer commands.
+//!
+//! This module provides commands for depositing and withdrawing USDC
+//! from Hyperliquid vaults.
+
+use alloy::primitives::Address;
+use clap::{Args, Subcommand};
+use hypersdk::{Decimal, hypercore::{HttpClient, NonceHandler}};
+
+use crate::SignerArgs;
+use crate::utils::find_signer_sync;
+
+/// Vault deposit and withdrawal commands.
+#[derive(Subcommand)]
+pub enum VaultCmd {
+    /// Deposit USDC into a vault
+    Deposit(VaultTransferCmd),
+    /// Withdraw USDC from a vault
+    Withdraw(VaultTransferCmd),
+}
+
+impl VaultCmd {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let (cmd, is_deposit) = match self {
+            VaultCmd::Deposit(cmd) => (cmd, true),
+            VaultCmd::Withdraw(cmd) => (cmd, false),
+        };
+
+        let signer = find_signer_sync(&cmd.signer)?;
+        let client = HttpClient::new(cmd.signer.chain);
+        let nonce = NonceHandler::default().next();
+
+        let (verb, past) = if is_deposit { ("Depositing", "Deposited") } else { ("Withdrawing", "Withdrawn") };
+        println!("{} ${} vault {}", verb, cmd.amount, cmd.vault);
+        client.vault_transfer(&signer, cmd.vault, cmd.amount, nonce, is_deposit).await?;
+        println!("{} successfully.", past);
+
+        Ok(())
+    }
+}
+
+/// Arguments for vault deposit and withdrawal.
+#[derive(Args, derive_more::Deref)]
+pub struct VaultTransferCmd {
+    #[deref]
+    #[command(flatten)]
+    pub signer: SignerArgs,
+
+    /// Vault address to deposit into or withdraw from
+    #[arg(long)]
+    pub vault: Address,
+
+    /// Amount of USDC to transfer
+    #[arg(long)]
+    pub amount: Decimal,
+}

--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -51,6 +51,7 @@ use alloy::{
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use serde::Deserialize;
 use url::Url;
 
@@ -60,7 +61,7 @@ use crate::hypercore::{
     PerpMarket, Signature, SpotMarket, SpotToken,
     api::{
         Action, ActionRequest, ApproveAgent, ConvertToMultiSigUser, OkResponse, Response,
-        SignersConfig,
+        SignersConfig, VaultTransfer,
     },
     mainnet_url, testnet_url,
     types::{
@@ -1464,6 +1465,39 @@ impl Client {
                 anyhow::bail!("send_usdc: {err}")
             }
             _ => anyhow::bail!("send_usdc: unexpected response type: {resp:?}"),
+        }
+    }
+
+    /// Deposit or withdraw USDC from a vault.
+    ///
+    /// # Parameters
+    ///
+    /// - `signer`: The signer for signing the action
+    /// - `vault_address`: The vault to deposit into or withdraw from
+    /// - `usd`: Amount of USDC (e.g. `dec!(100.5)` for $100.50; converted internally to micro-units)
+    /// - `nonce`: Unique nonce (typically current timestamp in milliseconds)
+    /// - `is_deposit`: `true` to deposit, `false` to withdraw
+    ///
+    /// <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#vault-transfer>
+    pub async fn vault_transfer<S: SignerSync>(
+        &self,
+        signer: &S,
+        vault_address: Address,
+        usd: Decimal,
+        nonce: u64,
+        is_deposit: bool,
+    ) -> Result<()> {
+        let usd_raw = (usd * rust_decimal::Decimal::from(1_000_000))
+            .to_u64()
+            .ok_or_else(|| anyhow::anyhow!("vault_transfer: usd amount out of range: {usd}"))?;
+        let action = VaultTransfer { vault_address, is_deposit, usd: usd_raw };
+        let resp = self
+            .sign_and_send_sync(signer, action, nonce, None, None)
+            .await?;
+        match resp {
+            Response::Ok(OkResponse::Default) => Ok(()),
+            Response::Err(err) => anyhow::bail!("vault_transfer: {err}"),
+            _ => anyhow::bail!("vault_transfer: unexpected response type: {resp:?}"),
         }
     }
 

--- a/src/hypercore/types/api.rs
+++ b/src/hypercore/types/api.rs
@@ -89,6 +89,8 @@ pub enum Action {
     ConvertToMultiSigUser(ConvertToMultiSigUser),
     /// Update isolated margin.
     UpdateIsolatedMargin(UpdateIsolatedMargin),
+    /// Deposit or withdraw from a vault.
+    VaultTransfer(VaultTransfer),
     /// Multi-sig action.
     MultiSig(MultiSigAction),
     /// Invalidate a request.
@@ -192,6 +194,7 @@ impl Action {
             | Action::ScheduleCancel(_)
             | Action::EvmUserModify { .. }
             | Action::UpdateIsolatedMargin(_)
+            | Action::VaultTransfer(_)
             | Action::Noop => {
                 let connection_id = self.hash(nonce, maybe_vault_address, expires_after)?;
                 let agent = solidity::Agent {
@@ -282,6 +285,7 @@ impl Action {
             | Action::ScheduleCancel(_)
             | Action::EvmUserModify { .. }
             | Action::UpdateIsolatedMargin(_)
+            | Action::VaultTransfer(_)
             | Action::Noop => {
                 let connection_id = self.hash(nonce, maybe_vault_address, expires_after)?;
                 let agent = solidity::Agent {
@@ -370,6 +374,7 @@ impl Action {
             | Action::ScheduleCancel(_)
             | Action::EvmUserModify { .. }
             | Action::UpdateIsolatedMargin(_)
+            | Action::VaultTransfer(_)
             | Action::Noop => {
                 let expires_after =
                     maybe_expires_after.map(|after| after.timestamp_millis() as u64);
@@ -661,6 +666,24 @@ pub struct UpdateIsolatedMargin {
     pub ntli: u64,
 }
 
+/// Deposit or withdraw USDC from a vault.
+///
+/// <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#vault-transfer>
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultTransfer {
+    /// The vault address to deposit into or withdraw from.
+    #[serde(
+        serialize_with = "crate::hypercore::utils::serialize_address_as_hex",
+        deserialize_with = "crate::hypercore::utils::deserialize_address_from_hex"
+    )]
+    pub vault_address: Address,
+    /// `true` for deposit, `false` for withdrawal.
+    pub is_deposit: bool,
+    /// Amount of USDC in micro-units (1 USD = 1,000,000).
+    pub usd: u64,
+}
+
 /// Multi-signature action payload.
 ///
 /// Contains the multisig user address, outer signer, and the inner action to execute.
@@ -844,5 +867,31 @@ mod tests {
             address,
             address!("0x5eCb62791B22A3108367c2A2024019Ee7eA88431")
         );
+    }
+
+    #[test]
+    fn vault_transfer_serialization() {
+        use alloy::primitives::address;
+
+        let action = Action::VaultTransfer(VaultTransfer {
+            vault_address: address!("dfc24b077bc1425ad1dea75bcb6f8158e10df303"),
+            is_deposit: true,
+            usd: 100_500_000, // 100.5 USDC in micro-units
+        });
+
+        let json = serde_json::to_string(&action).unwrap();
+        assert!(json.contains("\"type\":\"vaultTransfer\""));
+        assert!(json.contains("\"vaultAddress\":\"0xdfc24b077bc1425ad1dea75bcb6f8158e10df303\""));
+        assert!(json.contains("\"isDeposit\":true"));
+        assert!(json.contains("\"usd\":100500000"));
+
+        // Round-trip
+        let deserialized: Action = serde_json::from_str(&json).unwrap();
+        if let Action::VaultTransfer(vt) = deserialized {
+            assert!(vt.is_deposit);
+            assert_eq!(vt.usd, 100_500_000);
+        } else {
+            panic!("wrong variant");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `VaultTransfer` action struct with RMP+Agent signing support
- Add `HttpClient::vault_transfer()` for depositing/withdrawing USDC from vaults
- Add `vault_transfer` example for SDK usage
- Add `hypecli vault` command with `deposit` and `withdraw` subcommands

The `usd` field is serialized as a plain integer in micro-USDC units (1 USD = 1,000,000), consistent with other RMP-signed actions like `UpdateIsolatedMargin`. The public API accepts `Decimal` in USDC and converts internally.

## Usage

### SDK

```rust
// Deposit 100 USDC into a vault
client.vault_transfer(&signer, vault_address, dec!(100), nonce, true).await?;

// Withdraw 50.5 USDC from a vault
client.vault_transfer(&signer, vault_address, dec!(50.5), nonce, false).await?;
```

### Example

```bash
# Deposit 100 USDC
cargo run --example vault_transfer -- --vault 0x1234... --operation deposit --amount 100

# Withdraw 50 USDC
cargo run --example vault_transfer -- --vault 0x1234... --operation withdraw --amount 50
```

### hypecli

```bash
# Deposit (private key)
hypecli vault deposit --private-key <KEY> --vault 0x1234... --amount 100

# Withdraw (private key)
hypecli vault withdraw --private-key <KEY> --vault 0x1234... --amount 50

# Deposit (keystore)
hypecli vault deposit --keystore <NAME> --vault 0x1234... --amount 100

# Withdraw (keystore)
hypecli vault withdraw --keystore <NAME> --vault 0x1234... --amount 50
```