### PR TITLE
feat: add vault details command

### DIFF
--- a/hypecli/src/vault.rs
+++ b/hypecli/src/vault.rs
@@ -25,26 +25,21 @@ impl VaultCmd {
     pub async fn run(self) -> anyhow::Result<()> {
         match self {
             VaultCmd::Details(cmd) => cmd.run().await,
-            VaultCmd::Deposit(cmd) => {
-                let signer = find_signer_sync(&cmd.signer)?;
-                let client = HttpClient::new(cmd.signer.chain);
-                let nonce = NonceHandler::default().next();
-                println!("Depositing ${} vault {}", cmd.amount, cmd.vault);
-                client.vault_transfer(&signer, cmd.vault, cmd.amount, nonce, true).await?;
-                println!("Deposited successfully.");
-                Ok(())
-            }
-            VaultCmd::Withdraw(cmd) => {
-                let signer = find_signer_sync(&cmd.signer)?;
-                let client = HttpClient::new(cmd.signer.chain);
-                let nonce = NonceHandler::default().next();
-                println!("Withdrawing ${} vault {}", cmd.amount, cmd.vault);
-                client.vault_transfer(&signer, cmd.vault, cmd.amount, nonce, false).await?;
-                println!("Withdrawn successfully.");
-                Ok(())
-            }
+            VaultCmd::Deposit(cmd) => execute_transfer(cmd, true).await,
+            VaultCmd::Withdraw(cmd) => execute_transfer(cmd, false).await,
         }
     }
+}
+
+async fn execute_transfer(cmd: VaultTransferCmd, is_deposit: bool) -> anyhow::Result<()> {
+    let (verb, past) = if is_deposit { ("Depositing", "Deposited") } else { ("Withdrawing", "Withdrawn") };
+    let signer = find_signer_sync(&cmd.signer)?;
+    let client = HttpClient::new(cmd.signer.chain);
+    let nonce = NonceHandler::default().next();
+    println!("{} ${} vault {}", verb, cmd.amount, cmd.vault);
+    client.vault_transfer(&signer, cmd.vault, cmd.amount, nonce, is_deposit).await?;
+    println!("{} successfully.", past);
+    Ok(())
 }
 
 /// Arguments for vault deposit and withdrawal.
@@ -92,8 +87,9 @@ impl VaultDetailsCmd {
         println!("Max Withdrawable: ${}", details.max_withdrawable);
         println!();
         println!("Followers: {}", details.followers.len());
+        const DAY_PERIOD: &str = "day";
         let tvl = details.portfolio.iter()
-            .find(|(period, _)| period == "day")
+            .find(|(period, _)| period == DAY_PERIOD)
             .and_then(|(_, p)| p.account_value_history.iter().max_by_key(|(ts, _)| *ts))
             .map(|(_, value)| value.as_str());
         if let Some(tvl) = tvl {

--- a/hypecli/src/vault.rs
+++ b/hypecli/src/vault.rs
@@ -5,7 +5,7 @@
 
 use alloy::primitives::Address;
 use clap::{Args, Subcommand};
-use hypersdk::{Decimal, hypercore::{HttpClient, NonceHandler}};
+use hypersdk::{Decimal, hypercore::{self, HttpClient, NonceHandler}};
 
 use crate::SignerArgs;
 use crate::utils::find_signer_sync;
@@ -17,25 +17,33 @@ pub enum VaultCmd {
     Deposit(VaultTransferCmd),
     /// Withdraw USDC from a vault
     Withdraw(VaultTransferCmd),
+    /// Query details for a vault
+    Details(VaultDetailsCmd),
 }
 
 impl VaultCmd {
     pub async fn run(self) -> anyhow::Result<()> {
-        let (cmd, is_deposit) = match self {
-            VaultCmd::Deposit(cmd) => (cmd, true),
-            VaultCmd::Withdraw(cmd) => (cmd, false),
-        };
-
-        let signer = find_signer_sync(&cmd.signer)?;
-        let client = HttpClient::new(cmd.signer.chain);
-        let nonce = NonceHandler::default().next();
-
-        let (verb, past) = if is_deposit { ("Depositing", "Deposited") } else { ("Withdrawing", "Withdrawn") };
-        println!("{} ${} vault {}", verb, cmd.amount, cmd.vault);
-        client.vault_transfer(&signer, cmd.vault, cmd.amount, nonce, is_deposit).await?;
-        println!("{} successfully.", past);
-
-        Ok(())
+        match self {
+            VaultCmd::Details(cmd) => cmd.run().await,
+            VaultCmd::Deposit(cmd) => {
+                let signer = find_signer_sync(&cmd.signer)?;
+                let client = HttpClient::new(cmd.signer.chain);
+                let nonce = NonceHandler::default().next();
+                println!("Depositing ${} vault {}", cmd.amount, cmd.vault);
+                client.vault_transfer(&signer, cmd.vault, cmd.amount, nonce, true).await?;
+                println!("Deposited successfully.");
+                Ok(())
+            }
+            VaultCmd::Withdraw(cmd) => {
+                let signer = find_signer_sync(&cmd.signer)?;
+                let client = HttpClient::new(cmd.signer.chain);
+                let nonce = NonceHandler::default().next();
+                println!("Withdrawing ${} vault {}", cmd.amount, cmd.vault);
+                client.vault_transfer(&signer, cmd.vault, cmd.amount, nonce, false).await?;
+                println!("Withdrawn successfully.");
+                Ok(())
+            }
+        }
     }
 }
 
@@ -53,4 +61,57 @@ pub struct VaultTransferCmd {
     /// Amount of USDC to transfer
     #[arg(long)]
     pub amount: Decimal,
+}
+
+/// Arguments for vault details query.
+#[derive(Args)]
+pub struct VaultDetailsCmd {
+    /// Vault address to query
+    #[arg(long)]
+    pub vault: Address,
+
+    /// Optional user address to include follower state
+    #[arg(long)]
+    pub user: Option<Address>,
+}
+
+impl VaultDetailsCmd {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let client = hypercore::mainnet();
+        let details = client.vault_details(self.vault, self.user).await?;
+
+        println!("Vault: {}", details.name);
+        println!("Address: {:?}", details.vault_address);
+        println!("Leader: {:?}", details.leader);
+        println!("Description: {}", details.description);
+        println!();
+        println!("APR: {}%", details.apr * Decimal::ONE_HUNDRED);
+        println!("Leader Fraction: {}%", details.leader_fraction * Decimal::ONE_HUNDRED);
+        println!("Leader Commission: {}%", details.leader_commission * Decimal::ONE_HUNDRED);
+        println!("Max Distributable: ${}", details.max_distributable);
+        println!("Max Withdrawable: ${}", details.max_withdrawable);
+        println!();
+        println!("Followers: {}", details.followers.len());
+        let tvl = details.portfolio.iter()
+            .find(|(period, _)| period == "day")
+            .and_then(|(_, p)| p.account_value_history.iter().max_by_key(|(ts, _)| *ts))
+            .map(|(_, value)| value.as_str());
+        if let Some(tvl) = tvl {
+            println!("TVL: ${}", tvl);
+        }
+
+        if let Some(state) = details.follower_state {
+            println!();
+            println!("Your Position:");
+            println!("  Equity: ${}", state.vault_equity);
+            println!("  PnL: ${}", state.pnl);
+            println!("  All-time PnL: ${}", state.all_time_pnl);
+            println!("  Days Following: {}", state.days_following);
+            if let Some(lockup) = state.lockup_until {
+                println!("  Locked Until: {}", lockup);
+            }
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- Add new `vault details` subcommand to query vault information by address
- Displays vault name, leader, APR, TVL, follower count, and optional user position
- TVL is derived from the most recent entry in `account_value_history` using `max_by_key` on timestamp
- Refactor deposit/withdraw into shared `execute_transfer` helper to remove duplication

## Usage
```
# Query vault info
hypecli vault details --vault <vault-address>

# Include your follower position
hypecli vault details --vault <vault-address> --user <user-address>
```

## Example Output
```
Vault: My Vault
Address: 0x1234...abcd
Leader: 0xdead...beef
Description: a sample vault

APR: 120.50%
Leader Fraction: 5.00%
Leader Commission: 10.0%
Max Distributable: $1000000.00
Max Withdrawable: $500.00

Followers: 42
TVL: $1234567.89

Your Position:
  Equity: $10000.00
  PnL: $1500.00
  All-time PnL: $2000.00
  Days Following: 30
  Locked Until: 1773157273992
```