### PR TITLE
fix: Handle panics when metadata references indices beyond array length

### DIFF
--- a/src/hypercore/mod.rs
+++ b/src/hypercore/mod.rs
@@ -1273,12 +1273,12 @@ pub async fn spot_markets(
             .iter()
             .enumerate()
             .find(|(index, _)| *index as u32 == item.tokens[0])
-            .expect("base");
+            .context("base token index not found")?;
         let (_, quote) = spot_tokens
             .iter()
             .enumerate()
             .find(|(index, _)| *index as u32 == item.tokens[1])
-            .expect("quote");
+            .context("quote token index not found")?;
 
         markets.push(SpotMarket {
             name: item.name,
@@ -1377,7 +1377,10 @@ pub async fn perp_markets(
         .await
         .context("meta")?;
     let data: PerpTokens = resp.json().await?;
-    let collateral = &spot.tokens[data.collateral_token];
+    let collateral = spot
+        .tokens
+        .get(data.collateral_token)
+        .context("collateral token index out of bounds")?;
     let collateral = SpotToken::from(collateral.clone());
     let dex_index = dex.as_ref().map(|dex| dex.index).unwrap_or_default();
 


### PR DESCRIPTION
## Summary                                                   

The testnet API returns market metadata referencing token indices that exceed the token array bounds:               
                                                            
```bash
$ curl -s -X POST https://api.hyperliquid-testnet.xyz/info
   \                                                        
      -H 'Content-Type: application/json' \                 
      -d '{"type": "spotMeta"}' | jq '.tokens | length'     
1580   
                                                  
$ curl -s -X POST https://api.hyperliquid-testnet.xyz/info
   \                                                        
      -H 'Content-Type: application/json' \                 
      -d '{"type": "spotMeta"}' | jq '[.universe[].tokens[]]
   | max'                                                   
1827     
```                                                 
                                                            
  Markets like @1455 reference token index 1583, which doesn't exist in the 1580-element token array.                                                             
                                                            
  - Replace `expect()` with `context()` in `spot_markets()` when looking up base/quote tokens                              
  - Replace direct array indexing with `.get().context()` in `perp_markets()` for collateral token lookup  