### PR TITLE
feat: add nSigFigs/mantissa to Subscription::L2Book

### DIFF
--- a/hypecli/src/subscribe.rs
+++ b/hypecli/src/subscribe.rs
@@ -264,6 +264,8 @@ impl OrderbookCmd {
         let mut ws = core.websocket();
         ws.subscribe(Subscription::L2Book {
             coin: resolved.coin.clone(),
+            n_sig_figs: None,
+            mantissa: None,
         });
 
         eprintln!("Subscribing to {} orderbook...", self.asset);

--- a/src/hypercore/mod.rs
+++ b/src/hypercore/mod.rs
@@ -46,7 +46,11 @@
 //!
 //! // Subscribe to trades and order book
 //! ws.subscribe(Subscription::Trades { coin: "BTC".into() });
-//! ws.subscribe(Subscription::L2Book { coin: "BTC".into() });
+//! ws.subscribe(Subscription::L2Book {
+//!     coin: "BTC".into(),
+//!     n_sig_figs: None,
+//!     mantissa: None,
+//! });
 //!
 //! while let Some(event) = ws.next().await {
 //!     let Event::Message(msg) = event else { continue };

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -309,7 +309,13 @@ pub enum Subscription {
     Trades { coin: String },
     /// Order book snapshots and updates
     #[display("l2Book({coin})")]
-    L2Book { coin: String },
+    L2Book {
+        coin: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        n_sig_figs: Option<u8>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mantissa: Option<u8>,
+    },
     /// Real-time candlestick updates
     #[display("candle({coin}@{interval})")]
     Candle { coin: String, interval: String },

--- a/src/hypercore/ws.rs
+++ b/src/hypercore/ws.rs
@@ -58,7 +58,11 @@
 //!
 //! // Subscribe to trades and orderbook
 //! ws.subscribe(Subscription::Trades { coin: "BTC".into() });
-//! ws.subscribe(Subscription::L2Book { coin: "BTC".into() });
+//! ws.subscribe(Subscription::L2Book {
+//!     coin: "BTC".into(),
+//!     n_sig_figs: None,
+//!     mantissa: None,
+//! });
 //!
 //! while let Some(event) = ws.next().await {
 //!     let Event::Message(msg) = event else { continue };
@@ -323,7 +327,11 @@ pub struct Connection {
 /// // Manage subscriptions in a separate task
 /// spawn(async move {
 ///     handle.subscribe(Subscription::Trades { coin: "BTC".into() });
-///     handle.subscribe(Subscription::L2Book { coin: "ETH".into() });
+///     handle.subscribe(Subscription::L2Book {
+///         coin: "ETH".into(),
+///         n_sig_figs: None,
+///         mantissa: None,
+///     });
 ///
 ///     // Later, unsubscribe
 ///     tokio::time::sleep(std::time::Duration::from_secs(60)).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,11 @@
 //!
 //! // Subscribe to market data
 //! ws.subscribe(Subscription::Trades { coin: "BTC".into() });
-//! ws.subscribe(Subscription::L2Book { coin: "ETH".into() });
+//! ws.subscribe(Subscription::L2Book {
+//!     coin: "ETH".into(),
+//!     n_sig_figs: None,
+//!     mantissa: None,
+//! });
 //! ws.subscribe(Subscription::Candle {
 //!     coin: "BTC".into(),
 //!     interval: "15m".into()


### PR DESCRIPTION
Closes #39.

Adds optional `n_sig_figs` and `mantissa` fields to `Subscription::L2Book`, exposing the price level aggregation parameters already supported by the Hyperliquid WebSocket API.

- `n_sig_figs`: `2`, `3`, `4`, `5`, or `None` for raw precision
- `mantissa`: `1`, `2`, `5` (only valid when `n_sig_figs = Some(5)`)

Both fields serialize to camelCase (`nSigFigs`, `mantissa`) and are skipped when `None`, so on-wire behavior is unchanged for existing subscribers.

Note: this is a minor breaking change to the Rust API — construction sites of `L2Book` must now specify the two new fields (passing `None` preserves prior behavior). All internal call sites and compiled doctests are updated.