### PR TITLE
morpho vault apy: skip bad legs; add get_pool_address on uniswap client

### DIFF
--- a/src/hyperevm/morpho/mod.rs
+++ b/src/hyperevm/morpho/mod.rs
@@ -137,7 +137,8 @@ where
     /// Calculates the effective vault APY after fees.
     ///
     /// This is a weighted average of all underlying market APYs, adjusted for
-    /// the vault's management fee.
+    /// the vault's management fee. Components whose `supply_apy` does not fit in
+    /// `u128` are skipped instead of aborting the process.
     ///
     /// The return value is scaled to 18 decimals. Which means, if the
     /// APY of a vault is 4.20% the string representation of your decimal
@@ -211,7 +212,8 @@ where
 
                 // Convert shares to assets: shares * total_assets / total_shares = assets
                 let supplied_assets = supplied_shares * total_supply_assets / total_supply_shares;
-                let supply_apy = convert(U256::from(component.supply_apy.to_u128().unwrap()));
+                let supply_apy_raw = component.supply_apy.to_u128()?;
+                let supply_apy = convert(U256::from(supply_apy_raw));
                 Some(supplied_assets * supply_apy / total_deposits)
             })
             .fold(zero, |acc, x| acc + x);

--- a/src/hyperevm/uniswap/mod.rs
+++ b/src/hyperevm/uniswap/mod.rs
@@ -493,8 +493,8 @@ where
         Ok(positions)
     }
 
-    /// Get the pool address.
-    pub async fn get_pool_addres(
+    /// Resolves the Uniswap V3 pool contract for `token0`, `token1`, and `fee`.
+    pub async fn get_pool_address(
         &self,
         token0: Address,
         token1: Address,
@@ -512,6 +512,17 @@ where
             .aggregate()
             .await?;
         Ok(address)
+    }
+
+    /// Misspelled alias of [`Self::get_pool_address`].
+    #[deprecated(since = "0.2.9", note = "use get_pool_address instead")]
+    pub async fn get_pool_addres(
+        &self,
+        token0: Address,
+        token1: Address,
+        fee: u32,
+    ) -> Result<Address> {
+        self.get_pool_address(token0, token1, fee).await
     }
 
     /// Get the price from a pool.

--- a/src/hyperevm/uniswap/prjx/mod.rs
+++ b/src/hyperevm/uniswap/prjx/mod.rs
@@ -49,7 +49,7 @@ mod tests {
     async fn test_pool() {
         let client = mainnet().await.unwrap();
         let addy = client
-            .get_pool_addres(hyperevm::WHYPE_ADDRESS, UBTC_ADDRESS, 3000)
+            .get_pool_address(hyperevm::WHYPE_ADDRESS, UBTC_ADDRESS, 3000)
             .await
             .unwrap();
         assert_eq!(addy, address!("0x0D6ECB912b6ee160e95Bc198b618Acc1bCb92525"))


### PR DESCRIPTION
## morpho

`VaultApy::apy` used `supply_apy.to_u128().unwrap()`. If a vault leg ever reported an APY scalar that does not fit in `u128`, the whole call would panic. The weighted sum now skips that leg (same `filter_map` pattern as the existing zero-supply check) instead of aborting.

## uniswap

The pool resolver was published as `get_pool_addres` (typo). This adds `get_pool_address` with the implementation and keeps `get_pool_addres` as a deprecated wrapper that forwards to the new name so downstream crates keep compiling. The prjx test calls the new method.
