### PR TITLE
feat: add support for builder codes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ name = "user_role"
 path = "examples/hypercore/user_role.rs"
 
 [[example]]
+name = "max_builder_fee"
+path = "examples/hypercore/max_builder_fee.rs"
+
+[[example]]
 name = "user_fees"
 path = "examples/hypercore/user_fees.rs"
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ async fn main() -> anyhow::Result<()> {
             cloid: Default::default(),
         }],
         grouping: OrderGrouping::Na,
+        None,
     };
 
     let nonce = chrono::Utc::now().timestamp_millis() as u64;

--- a/examples/hypercore/buy_and_transfer.rs
+++ b/examples/hypercore/buy_and_transfer.rs
@@ -81,6 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cloid: Cloid::random(),
             }],
             grouping: OrderGrouping::Na,
+            builder: None,
         },
         nonce,
         None,

--- a/examples/hypercore/market_order.rs
+++ b/examples/hypercore/market_order.rs
@@ -64,6 +64,7 @@ async fn main() -> anyhow::Result<()> {
             nonce_handler.next(),
             None,
             None,
+            None,
         )
         .await?;
 

--- a/examples/hypercore/max_builder_fee.rs
+++ b/examples/hypercore/max_builder_fee.rs
@@ -28,7 +28,10 @@ async fn main() -> anyhow::Result<()> {
 
     println!("User:    {:?}", args.user);
     println!("Builder: {:?}", args.builder);
-    println!("Max approved builder fee: {} (tenths of a bps, e.g. 1 = 0.001%)", max_fee);
+    println!(
+        "Max approved builder fee: {} (tenths of a bps, e.g. 1 = 0.001%)",
+        max_fee
+    );
 
     Ok(())
 }

--- a/examples/hypercore/max_builder_fee.rs
+++ b/examples/hypercore/max_builder_fee.rs
@@ -1,0 +1,34 @@
+//! Query the maximum builder fee a user has approved for a builder on Hyperliquid.
+//!
+//! The value is expressed in tenths of a basis point (e.g. `1` means 0.001%).
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example max_builder_fee -- <USER_ADDRESS> <BUILDER_ADDRESS>
+//! ```
+
+use clap::Parser;
+use hypersdk::{Address, hypercore};
+
+#[derive(Parser)]
+struct Args {
+    /// User address to query the approved fee for
+    user: Address,
+    /// Builder address to check approval against
+    builder: Address,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let client = hypercore::mainnet();
+
+    let max_fee = client.max_builder_fee(args.user, args.builder).await?;
+
+    println!("User:    {:?}", args.user);
+    println!("Builder: {:?}", args.builder);
+    println!("Max approved builder fee: {} (tenths of a bps, e.g. 1 = 0.001%)", max_fee);
+
+    Ok(())
+}

--- a/examples/hypercore/multisig_order.rs
+++ b/examples/hypercore/multisig_order.rs
@@ -90,6 +90,7 @@ async fn main() -> anyhow::Result<()> {
             cloid: Cloid::random(),
         }],
         grouping: OrderGrouping::Na,
+        builder: None,
     };
 
     // Generate a unique nonce for this transaction

--- a/examples/hypercore/priority-fee-bid.rs
+++ b/examples/hypercore/priority-fee-bid.rs
@@ -11,8 +11,7 @@
 //! Note: The fee is deducted from your **spot** HYPE balance and burned.
 
 use clap::Parser;
-use hypersdk::hypercore::types::GossipPriorityAuctionStatus;
-use hypersdk::{hypercore, hyperevm};
+use hypersdk::{hypercore, hypercore::types::GossipPriorityAuctionStatus, hyperevm};
 use rust_decimal::Decimal;
 
 mod credentials;

--- a/examples/hypercore/send_order.rs
+++ b/examples/hypercore/send_order.rs
@@ -57,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
                     cloid: Cloid::random(),
                 }],
                 grouping: OrderGrouping::Na,
+                builder: None,
             },
             nonce.next(),
             vault_address,

--- a/hypecli/src/orders.rs
+++ b/hypecli/src/orders.rs
@@ -150,6 +150,7 @@ impl LimitOrderCmd {
         let batch = BatchOrder {
             orders: vec![order],
             grouping: OrderGrouping::Na,
+            builder: None,
         };
 
         let nonce = std::time::SystemTime::now()
@@ -242,6 +243,7 @@ impl MarketOrderCmd {
         let batch = BatchOrder {
             orders: vec![order],
             grouping: OrderGrouping::Na,
+            builder: None,
         };
 
         let nonce = std::time::SystemTime::now()

--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -57,16 +57,20 @@ use url::Url;
 
 use super::{AssetTarget, signing::*};
 use crate::hypercore::{
-    ActionError, ApiAgent, Builder, CandleInterval, Chain, Cloid, Dex, GossipPriorityAuctionStatus, Market, MultiSigConfig, OidOrCloid, OutcomeMeta, PerpMarket, Signature, SpotMarket, SpotToken, api::{
+    ActionError, ApiAgent, Builder, CandleInterval, Chain, Cloid, Dex, GossipPriorityAuctionStatus,
+    Market, MultiSigConfig, OidOrCloid, OutcomeMeta, PerpMarket, Signature, SpotMarket, SpotToken,
+    api::{
         Action, ActionRequest, ApproveAgent, ApproveBuilderFee, ConvertToMultiSigUser,
         GossipPriorityBid, OkResponse, Response, SignersConfig, UpdateLeverage, VaultTransfer,
-    }, mainnet_url, testnet_url, types::{
+    },
+    mainnet_url, testnet_url,
+    types::{
         AbstractionMode, AgentSendAsset, BasicOrder, BatchCancel, BatchCancelCloid, BatchModify,
         BatchOrder, ClearinghouseState, Fill, FundingRate, InfoRequest, OrderGrouping,
         OrderRequest, OrderResponseStatus, OrderTypePlacement, OrderUpdate, ScheduleCancel,
         SendAsset, SendToken, SpotSend, SubAccount, TimeInForce, UsdSend, UserBalance, UserFees,
         UserRole, UserSetAbstractionAction, UserVaultEquity, VaultDetails,
-    }
+    },
 };
 
 /// HTTP client for HyperCore API.

--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -50,8 +50,7 @@ use alloy::{
 };
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
-use rust_decimal::Decimal;
-use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::{Decimal, prelude::ToPrimitive};
 use serde::Deserialize;
 use url::Url;
 

--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -1884,6 +1884,34 @@ impl Client {
     // Account Abstraction Mode actions
     // -----------------------------------------------------------------
 
+    /// Check builder fee approval for a user.
+    ///
+    /// Returns the maximum builder fee approved by `user` for `builder`,
+    /// expressed in tenths of a basis point (e.g. `1` means 0.001%).
+    /// Returns `0` if no approval has been granted.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use hypersdk::hypercore;
+    /// use hypersdk::Address;
+    ///
+    /// # async fn example() -> anyhow::Result<()> {
+    /// let client = hypercore::mainnet();
+    /// let user: Address = "0x...".parse()?;
+    /// let builder: Address = "0x...".parse()?;
+    /// let max_fee = client.check_builder_fee_approval(user, builder).await?;
+    /// println!("Max approved fee: {} (tenths of a bps)", max_fee);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#check-builder-fee-approval>
+    pub async fn check_builder_fee_approval(&self, user: Address, builder: Address) -> Result<u32> {
+        let req = InfoRequest::CheckBuilderFeeApproval { user, builder };
+        self.send_info_request("check_builder_fee_approval", &req).await
+    }
+
     /// Query the current account abstraction mode for a user.
     ///
     /// Sends an info request to `/info` with type `"abstraction"`.

--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -1884,9 +1884,9 @@ impl Client {
     // Account Abstraction Mode actions
     // -----------------------------------------------------------------
 
-    /// Check builder fee approval for a user.
+    /// Query the maximum builder fee approved by a user for a specific builder.
     ///
-    /// Returns the maximum builder fee approved by `user` for `builder`,
+    /// Returns the maximum fee approved by `user` for `builder`,
     /// expressed in tenths of a basis point (e.g. `1` means 0.001%).
     /// Returns `0` if no approval has been granted.
     ///
@@ -1900,16 +1900,16 @@ impl Client {
     /// let client = hypercore::mainnet();
     /// let user: Address = "0x...".parse()?;
     /// let builder: Address = "0x...".parse()?;
-    /// let max_fee = client.check_builder_fee_approval(user, builder).await?;
+    /// let max_fee = client.max_builder_fee(user, builder).await?;
     /// println!("Max approved fee: {} (tenths of a bps)", max_fee);
     /// # Ok(())
     /// # }
     /// ```
     ///
     /// <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#check-builder-fee-approval>
-    pub async fn check_builder_fee_approval(&self, user: Address, builder: Address) -> Result<u32> {
-        let req = InfoRequest::CheckBuilderFeeApproval { user, builder };
-        self.send_info_request("check_builder_fee_approval", &req).await
+    pub async fn max_builder_fee(&self, user: Address, builder: Address) -> Result<u32> {
+        let req = InfoRequest::MaxBuilderFee { user, builder };
+        self.send_info_request("max_builder_fee", &req).await
     }
 
     /// Query the current account abstraction mode for a user.

--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -1368,13 +1368,13 @@ impl Client {
     /// # Parameters
     ///
     /// - `signer`: The wallet signing the approval
-    /// - `builder`: Builder address in 42-character hexadecimal format
+    /// - `builder`: Builder address
     /// - `max_fee_rate`: Max fee as percent string (e.g. `"0.001%"`)
     /// - `nonce`: The nonce for this action
     pub async fn approve_builder_fee<S: Signer + Send + Sync>(
         &self,
         signer: &S,
-        builder: String,
+        builder: Address,
         max_fee_rate: String,
         nonce: u64,
     ) -> Result<()> {
@@ -2660,7 +2660,7 @@ where
     }
 
     /// Approve the maximum fee rate a builder can charge for routed orders.
-    pub async fn approve_builder_fee(&self, builder: String, max_fee_rate: String) -> Result<()> {
+    pub async fn approve_builder_fee(&self, builder: Address, max_fee_rate: String) -> Result<()> {
         let chain = self.client.chain;
 
         let approve_builder_fee = ApproveBuilderFee {

--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -1150,7 +1150,7 @@ impl Client {
     ///
     /// // Market buy 0.01 ETH, accepting fills up to 3500 USDC
     /// let statuses = client
-    ///     .market_open(&signer, eth, true, rust_decimal::dec!(3500), rust_decimal::dec!(0.01), nonce_handler.next(), None, None)
+    ///     .market_open(&signer, eth, true, rust_decimal::dec!(3500), rust_decimal::dec!(0.01), nonce_handler.next(), None, None, None)
     ///     .await?;
     ///
     /// for status in &statuses {

--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -57,20 +57,16 @@ use url::Url;
 
 use super::{AssetTarget, signing::*};
 use crate::hypercore::{
-    ActionError, ApiAgent, CandleInterval, Chain, Cloid, Dex, GossipPriorityAuctionStatus, Market,
-    MultiSigConfig, OidOrCloid, OutcomeMeta, PerpMarket, Signature, SpotMarket, SpotToken,
-    api::{
-        Action, ActionRequest, ApproveAgent, ConvertToMultiSigUser, GossipPriorityBid, OkResponse,
-        Response, SignersConfig, UpdateLeverage, VaultTransfer,
-    },
-    mainnet_url, testnet_url,
-    types::{
+    ActionError, ApiAgent, Builder, CandleInterval, Chain, Cloid, Dex, GossipPriorityAuctionStatus, Market, MultiSigConfig, OidOrCloid, OutcomeMeta, PerpMarket, Signature, SpotMarket, SpotToken, api::{
+        Action, ActionRequest, ApproveAgent, ApproveBuilderFee, ConvertToMultiSigUser,
+        GossipPriorityBid, OkResponse, Response, SignersConfig, UpdateLeverage, VaultTransfer,
+    }, mainnet_url, testnet_url, types::{
         AbstractionMode, AgentSendAsset, BasicOrder, BatchCancel, BatchCancelCloid, BatchModify,
         BatchOrder, ClearinghouseState, Fill, FundingRate, InfoRequest, OrderGrouping,
         OrderRequest, OrderResponseStatus, OrderTypePlacement, OrderUpdate, ScheduleCancel,
         SendAsset, SendToken, SpotSend, SubAccount, TimeInForce, UsdSend, UserBalance, UserFees,
         UserRole, UserSetAbstractionAction, UserVaultEquity, VaultDetails,
-    },
+    }
 };
 
 /// HTTP client for HyperCore API.
@@ -1174,6 +1170,7 @@ impl Client {
         nonce: u64,
         vault_address: Option<Address>,
         expires_after: Option<DateTime<Utc>>,
+        builder: Option<Builder>,
     ) -> Result<Vec<OrderResponseStatus>> {
         let batch = BatchOrder {
             orders: vec![OrderRequest {
@@ -1188,6 +1185,7 @@ impl Client {
                 cloid: Default::default(),
             }],
             grouping: OrderGrouping::Na,
+            builder,
         };
 
         self.place(signer, batch, nonce, vault_address, expires_after)
@@ -1359,6 +1357,41 @@ impl Client {
                 anyhow::bail!("approve_agent: {err}")
             }
             _ => anyhow::bail!("approve_agent: unexpected response type: {resp:?}"),
+        }
+    }
+
+    /// Approve the maximum fee rate a builder can charge for routed orders.
+    ///
+    /// # Parameters
+    ///
+    /// - `signer`: The wallet signing the approval
+    /// - `builder`: Builder address in 42-character hexadecimal format
+    /// - `max_fee_rate`: Max fee as percent string (e.g. `"0.001%"`)
+    /// - `nonce`: The nonce for this action
+    pub async fn approve_builder_fee<S: Signer + Send + Sync>(
+        &self,
+        signer: &S,
+        builder: String,
+        max_fee_rate: String,
+        nonce: u64,
+    ) -> Result<()> {
+        let approve_builder_fee = ApproveBuilderFee {
+            signature_chain_id: self.chain.arbitrum_id().to_owned(),
+            hyperliquid_chain: self.chain,
+            max_fee_rate,
+            builder,
+            nonce,
+        };
+
+        let resp = self
+            .sign_and_send(signer, approve_builder_fee, nonce, None, None)
+            .await?;
+        match resp {
+            Response::Ok(OkResponse::Default) => Ok(()),
+            Response::Err(err) => {
+                anyhow::bail!("approve_builder_fee: {err}")
+            }
+            _ => anyhow::bail!("approve_builder_fee: unexpected response type: {resp:?}"),
         }
     }
 
@@ -2321,6 +2354,7 @@ where
     /// let batch = BatchOrder {
     ///     orders: vec![order],
     ///     grouping: OrderGrouping::Na,
+    ///     builder: None,
     /// };
     ///
     /// let statuses = client
@@ -2591,6 +2625,41 @@ where
             Response::Ok(OkResponse::Default) => Ok(()),
             Response::Err(err) => anyhow::bail!("approve_agent: {err}"),
             _ => anyhow::bail!("approve_agent: unexpected response type: {resp:?}"),
+        }
+    }
+
+    /// Approve the maximum fee rate a builder can charge for routed orders.
+    pub async fn approve_builder_fee(&self, builder: String, max_fee_rate: String) -> Result<()> {
+        let chain = self.client.chain;
+
+        let approve_builder_fee = ApproveBuilderFee {
+            signature_chain_id: chain.arbitrum_id().to_owned(),
+            hyperliquid_chain: chain,
+            max_fee_rate,
+            builder,
+            nonce: self.nonce,
+        };
+
+        let action = multisig_collect_signatures(
+            self.lead.address(),
+            self.multi_sig_user,
+            self.signers.iter().copied(),
+            self.signatures.iter().copied(),
+            Action::ApproveBuilderFee(approve_builder_fee),
+            self.nonce,
+            self.client.chain,
+        )
+        .await?;
+
+        let resp = self
+            .client
+            .sign_and_send(self.lead, action, self.nonce, None, None)
+            .await?;
+
+        match resp {
+            Response::Ok(OkResponse::Default) => Ok(()),
+            Response::Err(err) => anyhow::bail!("approve_builder_fee: {err}"),
+            _ => anyhow::bail!("approve_builder_fee: unexpected response type: {resp:?}"),
         }
     }
 

--- a/src/hypercore/signing.rs
+++ b/src/hypercore/signing.rs
@@ -306,6 +306,7 @@ mod tests {
                 cloid: Default::default(),
             }],
             grouping: OrderGrouping::Na,
+            builder: None,
         };
 
         let action = Action::Order(order.clone());
@@ -346,6 +347,7 @@ mod tests {
                 cloid: Default::default(),
             }],
             grouping: OrderGrouping::PriorityRate(80_000),
+            builder: None,
         };
 
         let action = Action::Order(batch.clone());

--- a/src/hypercore/types/api.rs
+++ b/src/hypercore/types/api.rs
@@ -250,8 +250,7 @@ impl Action {
                 signer.sign_dynamic_typed_data_sync(&typed_data)?
             }
             Action::ApproveBuilderFee(inner) => {
-                let typed_data =
-                    get_typed_data::<solidity::ApproveBuilderFee>(&inner, chain, None);
+                let typed_data = get_typed_data::<solidity::ApproveBuilderFee>(&inner, chain, None);
                 signer.sign_dynamic_typed_data_sync(&typed_data)?
             }
             Action::ConvertToMultiSigUser(inner) => {
@@ -363,8 +362,7 @@ impl Action {
                 signer.sign_dynamic_typed_data(&typed_data).await?
             }
             Action::ApproveBuilderFee(inner) => {
-                let typed_data =
-                    get_typed_data::<solidity::ApproveBuilderFee>(&inner, chain, None);
+                let typed_data = get_typed_data::<solidity::ApproveBuilderFee>(&inner, chain, None);
                 signer.sign_dynamic_typed_data(&typed_data).await?
             }
             Action::ConvertToMultiSigUser(inner) => {
@@ -472,8 +470,7 @@ impl Action {
                 Ok(typed_data.eip712_signing_hash()?)
             }
             Action::ApproveBuilderFee(inner) => {
-                let typed_data =
-                    get_typed_data::<solidity::ApproveBuilderFee>(&inner, chain, None);
+                let typed_data = get_typed_data::<solidity::ApproveBuilderFee>(&inner, chain, None);
                 Ok(typed_data.eip712_signing_hash()?)
             }
             Action::ConvertToMultiSigUser(inner) => {

--- a/src/hypercore/types/api.rs
+++ b/src/hypercore/types/api.rs
@@ -748,8 +748,8 @@ pub struct ApproveBuilderFee {
     pub hyperliquid_chain: Chain,
     /// The maximum allowed builder fee rate as a percent string; e.g. "0.001%".
     pub max_fee_rate: String,
-    /// Builder address in 42-character hexadecimal format.
-    pub builder: String,
+    /// Builder address.
+    pub builder: Address,
     /// Request nonce (timestamp in milliseconds).
     /// Must match nonce in outer request body.
     pub nonce: u64,
@@ -1289,7 +1289,9 @@ mod tests {
             signature_chain_id: "0xa4b1".to_string(),
             hyperliquid_chain: Chain::Mainnet,
             max_fee_rate: "0.001%".to_string(),
-            builder: "0x8c967e73e7b15087c42a10d344cff4c96d877f1d".to_string(),
+            builder: "0x8c967e73e7b15087c42a10d344cff4c96d877f1d"
+                .parse()
+                .unwrap(),
             nonce: 1_700_000_000_000,
         });
 
@@ -1303,7 +1305,12 @@ mod tests {
         match deserialized {
             Action::ApproveBuilderFee(inner) => {
                 assert_eq!(inner.max_fee_rate, "0.001%");
-                assert_eq!(inner.builder, "0x8c967e73e7b15087c42a10d344cff4c96d877f1d");
+                assert_eq!(
+                    inner.builder,
+                    "0x8c967e73e7b15087c42a10d344cff4c96d877f1d"
+                        .parse::<Address>()
+                        .unwrap()
+                );
                 assert_eq!(inner.nonce, 1_700_000_000_000);
             }
             _ => assert!(false, "wrong variant"),

--- a/src/hypercore/types/api.rs
+++ b/src/hypercore/types/api.rs
@@ -88,6 +88,8 @@ pub enum Action {
         using_big_blocks: bool,
     },
     ApproveAgent(ApproveAgent),
+    /// Approve maximum builder fee for a builder address.
+    ApproveBuilderFee(ApproveBuilderFee),
     /// Convert to multi-signature user.
     ConvertToMultiSigUser(ConvertToMultiSigUser),
     /// Update isolated margin.
@@ -247,6 +249,11 @@ impl Action {
                 let typed_data = get_typed_data::<solidity::ApproveAgent>(&inner, chain, None);
                 signer.sign_dynamic_typed_data_sync(&typed_data)?
             }
+            Action::ApproveBuilderFee(inner) => {
+                let typed_data =
+                    get_typed_data::<solidity::ApproveBuilderFee>(&inner, chain, None);
+                signer.sign_dynamic_typed_data_sync(&typed_data)?
+            }
             Action::ConvertToMultiSigUser(inner) => {
                 let typed_data =
                     get_typed_data::<solidity::ConvertToMultiSigUser>(&inner, chain, None);
@@ -355,6 +362,11 @@ impl Action {
                 let typed_data = get_typed_data::<solidity::ApproveAgent>(&inner, chain, None);
                 signer.sign_dynamic_typed_data(&typed_data).await?
             }
+            Action::ApproveBuilderFee(inner) => {
+                let typed_data =
+                    get_typed_data::<solidity::ApproveBuilderFee>(&inner, chain, None);
+                signer.sign_dynamic_typed_data(&typed_data).await?
+            }
             Action::ConvertToMultiSigUser(inner) => {
                 let typed_data =
                     get_typed_data::<solidity::ConvertToMultiSigUser>(&inner, chain, None);
@@ -457,6 +469,11 @@ impl Action {
             }
             Action::ApproveAgent(inner) => {
                 let typed_data = get_typed_data::<solidity::ApproveAgent>(&inner, chain, None);
+                Ok(typed_data.eip712_signing_hash()?)
+            }
+            Action::ApproveBuilderFee(inner) => {
+                let typed_data =
+                    get_typed_data::<solidity::ApproveBuilderFee>(&inner, chain, None);
                 Ok(typed_data.eip712_signing_hash()?)
             }
             Action::ConvertToMultiSigUser(inner) => {
@@ -715,6 +732,29 @@ pub struct ApproveAgent {
     /// up to 3 named ones, and 2 named agents per subaccount.
     pub agent_name: Option<String>,
     /// Request nonce
+    pub nonce: u64,
+}
+
+/// Approve builder fee.
+///
+/// Approves the maximum fee rate a builder is allowed to charge for routed orders.
+///
+/// <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#approve-a-builder-fee>
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ApproveBuilderFee {
+    /// Signature chain ID.
+    ///
+    /// For arbitrum use [`crate::hypercore::ARBITRUM_MAINNET_CHAIN_ID`] or [`crate::hypercore::ARBITRUM_TESTNET_CHAIN_ID`].
+    pub signature_chain_id: String,
+    /// The chain this action is being executed on.
+    pub hyperliquid_chain: Chain,
+    /// The maximum allowed builder fee rate as a percent string; e.g. "0.001%".
+    pub max_fee_rate: String,
+    /// Builder address in 42-character hexadecimal format.
+    pub builder: String,
+    /// Request nonce (timestamp in milliseconds).
+    /// Must match nonce in outer request body.
     pub nonce: u64,
 }
 
@@ -1243,6 +1283,33 @@ mod tests {
             assert_eq!(ul.leverage, 10);
         } else {
             assert!(false, "wrong variant");
+        }
+    }
+
+    #[test]
+    fn approve_builder_fee_serialization() {
+        let action = Action::ApproveBuilderFee(ApproveBuilderFee {
+            signature_chain_id: "0xa4b1".to_string(),
+            hyperliquid_chain: Chain::Mainnet,
+            max_fee_rate: "0.001%".to_string(),
+            builder: "0x8c967e73e7b15087c42a10d344cff4c96d877f1d".to_string(),
+            nonce: 1_700_000_000_000,
+        });
+
+        let json = serde_json::to_string(&action).unwrap();
+        assert!(json.contains("\"type\":\"approveBuilderFee\""));
+        assert!(json.contains("\"maxFeeRate\":\"0.001%\""));
+        assert!(json.contains("\"builder\":\"0x8c967e73e7b15087c42a10d344cff4c96d877f1d\""));
+        assert!(json.contains("\"nonce\":1700000000000"));
+
+        let deserialized: Action = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            Action::ApproveBuilderFee(inner) => {
+                assert_eq!(inner.max_fee_rate, "0.001%");
+                assert_eq!(inner.builder, "0x8c967e73e7b15087c42a10d344cff4c96d877f1d");
+                assert_eq!(inner.nonce, 1_700_000_000_000);
+            }
+            _ => assert!(false, "wrong variant"),
         }
     }
 

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -89,10 +89,9 @@ pub mod api;
 pub(super) mod solidity;
 
 // Re-export important raw types for convenience
-pub use api::AbstractionMode;
 pub use api::{
-    Action, ActionRequest, ApproveBuilderFee, GossipPriorityBid, MultiSigAction, MultiSigPayload,
-    OkResponse, Response, UserDexAbstractionAction, UserSetAbstractionAction,
+    AbstractionMode, Action, ActionRequest, ApproveBuilderFee, GossipPriorityBid, MultiSigAction,
+    MultiSigPayload, OkResponse, Response, UserDexAbstractionAction, UserSetAbstractionAction,
 };
 // Import from raw module (which is now a submodule)
 use api::{AgentSendAssetAction, SendAssetAction, SpotSendAction, UsdSendAction};

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -3532,6 +3532,11 @@ pub(super) enum InfoRequest {
     AbstractionMode {
         user: Address,
     },
+    /// Check builder fee approval for a user.
+    CheckBuilderFeeApproval {
+        user: Address,
+        builder: Address,
+    },
 }
 
 #[cfg(test)]

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -2204,9 +2204,11 @@ pub struct BatchOrder {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Builder {
     /// Builder address.
-    pub b: String,
+    #[serde(rename = "b")]
+    pub builder_address: Address,
     /// Builder fee in tenths of basis points.
-    pub f: u32,
+    #[serde(rename = "f")]
+    pub fee: u32,
 }
 
 /// Grouping type for batch orders.

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -3533,7 +3533,7 @@ pub(super) enum InfoRequest {
         user: Address,
     },
     /// Check builder fee approval for a user.
-    CheckBuilderFeeApproval {
+    MaxBuilderFee {
         user: Address,
         builder: Address,
     },

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -91,8 +91,8 @@ pub(super) mod solidity;
 // Re-export important raw types for convenience
 pub use api::AbstractionMode;
 pub use api::{
-    Action, ActionRequest, GossipPriorityBid, MultiSigAction, MultiSigPayload, OkResponse,
-    Response, UserDexAbstractionAction, UserSetAbstractionAction,
+    Action, ActionRequest, ApproveBuilderFee, GossipPriorityBid, MultiSigAction, MultiSigPayload,
+    OkResponse, Response, UserDexAbstractionAction, UserSetAbstractionAction,
 };
 // Import from raw module (which is now a submodule)
 use api::{AgentSendAssetAction, SendAssetAction, SpotSendAction, UsdSendAction};
@@ -2159,6 +2159,7 @@ impl OrderResponseStatus {
 ///         }
 ///     ],
 ///     grouping: OrderGrouping::Na,
+///     builder: None,
 /// };
 /// ```
 ///
@@ -2183,6 +2184,7 @@ impl OrderResponseStatus {
 ///         }
 ///     ],
 ///     grouping: OrderGrouping::PriorityRate(80_000), // 8 bps max
+///     builder: None,
 /// };
 /// ```
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -2190,6 +2192,22 @@ impl OrderResponseStatus {
 pub struct BatchOrder {
     pub orders: Vec<OrderRequest>,
     pub grouping: OrderGrouping,
+    /// Optional builder to receive fees for routed orders.
+    ///
+    /// User must approve a maximum fee first via [`api::ApproveBuilderFee`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builder: Option<Builder>,
+}
+
+/// Builder fee metadata attached to an order action.
+///
+/// Serialized under the `builder` key as `{ "b": <address>, "f": <tenths_of_bps> }`.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct Builder {
+    /// Builder address.
+    pub b: String,
+    /// Builder fee in tenths of basis points.
+    pub f: u32,
 }
 
 /// Grouping type for batch orders.
@@ -4359,6 +4377,7 @@ mod tests {
                 cloid: Default::default(),
             }],
             grouping: OrderGrouping::PriorityRate(80_000),
+            builder: None,
         };
 
         let json = serde_json::to_string(&batch).unwrap();

--- a/src/hypercore/types/solidity.rs
+++ b/src/hypercore/types/solidity.rs
@@ -44,6 +44,13 @@ sol! {
         uint64 nonce;
     }
 
+    struct ApproveBuilderFee {
+        string hyperliquidChain;
+        string maxFeeRate;
+        address builder;
+        uint64 nonce;
+    }
+
     struct ConvertToMultiSigUser {
         string hyperliquidChain;
         string signers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@
 //!         cloid: Default::default(),
 //!     }],
 //!     grouping: OrderGrouping::Na,
+//!     builder: None,
 //! };
 //!
 //! let nonce = chrono::Utc::now().timestamp_millis() as u64;


### PR DESCRIPTION
Adds builder code support by:

- Updated `Actions` to support `ApproveBuilderFee`
- Added support for `maxBuilderFee` info request
  - Added working example matching other examples patterns
- Some import reorganization as a result of running `cargo fmt --all`
- Updated tests and doc tests as appropriate

Resolves #50 