### PR TITLE
fix: use local path for `hypersdk` version in `hypecli`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 ## Package metadata
 [package]
 name = "hypersdk"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 authors = ["Dario <dario@infinitefieldtrading.com>"]
 license = "MPL-2.0"

--- a/hypecli/Cargo.lock
+++ b/hypecli/Cargo.lock
@@ -2618,7 +2618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3378,9 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "hypersdk"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67469c8876c6403ebd03357cb9fb9de9ac62978edce481815dcc4a8114ac8386"
+version = "0.2.11"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3399,6 +3397,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-util",
  "url",
  "yawc",
 ]
@@ -4458,7 +4457,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5652,7 +5651,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5732,7 +5731,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6500,7 +6499,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7334,7 +7333,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/hypecli/Cargo.toml
+++ b/hypecli/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 # hypersdk = { path = ".." }
 
 [dependencies]
-hypersdk = { path = "..", version = "0.2.11" }
+hypersdk = { path = "..", version = "0.2.12" }
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.43.1", features = [
     "rt",

--- a/hypecli/Cargo.toml
+++ b/hypecli/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 # hypersdk = { path = ".." }
 
 [dependencies]
-hypersdk = { version = "0.2" }
+hypersdk = { path = "..", version = "0.2.11" }
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.43.1", features = [
     "rt",

--- a/hypecli/src/balances.rs
+++ b/hypecli/src/balances.rs
@@ -99,7 +99,7 @@ impl BalanceCmd {
         // Query all DEXes (unless --skip-hip3 is set)
         let mut dex_states = Vec::new();
         if !self.skip_hip3 {
-            let dexes = core.perp_dexs().await?;
+            let dexes = core.perp_dexes().await?;
             for dex in &dexes {
                 let dex_name = dex.name();
                 let state = core

--- a/hypecli/src/markets.rs
+++ b/hypecli/src/markets.rs
@@ -41,7 +41,7 @@ impl PerpsCmd {
         let core = hypercore::mainnet();
 
         let perps = if let Some(dex_name) = &self.dex {
-            let dexes = core.perp_dexs().await?;
+            let dexes = core.perp_dexes().await?;
             let dex = dexes
                 .iter()
                 .find(|d| d.name().eq_ignore_ascii_case(dex_name))
@@ -103,7 +103,7 @@ pub struct DexesCmd;
 impl DexesCmd {
     pub async fn run(self) -> anyhow::Result<()> {
         let core = hypercore::mainnet();
-        let dexes = core.perp_dexs().await?;
+        let dexes = core.perp_dexes().await?;
 
         println!("name");
         for dex in dexes {

--- a/hypecli/src/utils.rs
+++ b/hypecli/src/utils.rs
@@ -319,8 +319,8 @@ pub async fn resolve_asset(client: &HttpClient, asset: &str) -> anyhow::Result<u
         }
         AssetSpec::Hip3Perp(dex_name, symbol) => {
             // First get the DEX
-            let dexs = client.perp_dexs().await?;
-            let dex = dexs
+            let dexes = client.perp_dexes().await?;
+            let dex = dexes
                 .iter()
                 .find(|d| d.name().eq_ignore_ascii_case(dex_name))
                 .ok_or_else(|| anyhow::anyhow!("HIP3 DEX '{}' not found", dex_name))?;
@@ -540,8 +540,8 @@ pub async fn resolve_asset_for_subscription(
         }
         AssetSpec::Hip3Perp(dex_name, symbol) => {
             // First get the DEX
-            let dexs = client.perp_dexs().await?;
-            let dex = dexs
+            let dexes = client.perp_dexes().await?;
+            let dex = dexes
                 .iter()
                 .find(|d| d.name().eq_ignore_ascii_case(dex_name))
                 .ok_or_else(|| anyhow::anyhow!("HIP3 DEX '{}' not found", dex_name))?;


### PR DESCRIPTION
- This resolves CI/CD build errors by using a local path for `hypersdk` inside of `hypecli` rather than using a pinned public version
- However, this will **not work** once `hypecli` is published since Cargo will resolve the `hypersdk` dependency from the registry
- Bumps `hypersdk` to `v0.2.12`
- Fixes deprecation warnings for usages of `perp_dexs`