### PR TITLE
fix(info): use userAbstraction request type for AbstractionMode query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `BasicOrder` trigger-order fields from `frontendOpenOrders`: `is_trigger`, `trigger_px`, `trigger_condition`, `is_position_tpsl`
 - `OrderResponseStatus::WaitingForTrigger` and `WaitingForFill` order response variants
 
+### Fixed
+
+- Use `userAbstraction` as the info request type for `AbstractionMode` queries
+
 ## [v0.2.10]
 
 ### Added

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -3619,6 +3619,7 @@ pub(super) enum InfoRequest {
     /// Query gossip priority auction status.
     GossipPriorityAuctionStatus,
     /// Query account abstraction mode for a user.
+    #[serde(rename = "userAbstraction")]
     AbstractionMode {
         user: Address,
     },


### PR DESCRIPTION
`InfoRequest` uses `rename_all = "camelCase"`, so `AbstractionMode` serialized its `type` tag as `abstractionMode`.
The API expects `userAbstraction`, so the query never worked. This adds the rename.

Confirmed against the Python SDK, where `query_user_abstraction_state` posts `{"type": "userAbstraction", ...}`.

Reproduced against the live API:

```text
# before — rejected
{"type": "abstractionMode",  "user": "0x..."}  ->  HTTP 422  "Failed to deserialize the JSON body"
# after — works
{"type": "userAbstraction", "user": "0x..."}  ->  HTTP 200  "unifiedAccount"
```

Ref: https://github.com/hyperliquid-dex/hyperliquid-python-sdk/blob/master/hyperliquid/info.py#L635
