### PR TITLE
fixed user abstraction info request

### DIFF
--- a/src/hypercore/http.rs
+++ b/src/hypercore/http.rs
@@ -1932,11 +1932,13 @@ impl Client {
     ///
     /// <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#retrieve-abstraction-mode>
     pub async fn abstraction_mode(&self, user: Address) -> Result<AbstractionMode> {
-        let req = InfoRequest::AbstractionMode { user };
+        let req = InfoRequest::UserAbstraction { user };
         // Response is a plain string like "unifiedAccount" or "disabled"
-        let s: String = self.send_info_request("abstraction_mode", &req).await?;
+        let s: String = self
+            .send_info_request("user_abstraction_mode", &req)
+            .await?;
         AbstractionMode::from_api_str(&s)
-            .map_err(|e| anyhow!("failed to parse abstraction mode: {e}"))
+            .map_err(|e| anyhow!("failed to parse user abstraction mode: {e}"))
     }
 
     /// Set abstraction mode via agent-signed action (L1/RMP signing).

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -3619,7 +3619,7 @@ pub(super) enum InfoRequest {
     /// Query gossip priority auction status.
     GossipPriorityAuctionStatus,
     /// Query account abstraction mode for a user.
-    AbstractionMode {
+    UserAbstraction {
         user: Address,
     },
     /// Check builder fee approval for a user.


### PR DESCRIPTION
request body `type` must be `userAbstraction`  instead of  `abstractionMode`

https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#query-a-users-abstraction-state