### PR TITLE
fix(hypercore): match spot tokens by index field, not array position

### DIFF
--- a/src/hypercore/mod.rs
+++ b/src/hypercore/mod.rs
@@ -1522,15 +1522,18 @@ pub async fn spot_markets(
     let spot_tokens: Vec<_> = data.tokens.iter().cloned().map(SpotToken::from).collect();
 
     for item in data.universe {
-        let (_, base) = spot_tokens
+        // Match by the token's `index` field, NOT its position in the `tokens`
+        // array. HyperCore's token indices are not contiguous (delistings /
+        // reindexing leave gaps), so position-based lookup panics/errors once a
+        // universe market references a token whose index exceeds the array length
+        // (e.g. mainnet market `@367` -> base token index 479 in a 464-entry array).
+        let base = spot_tokens
             .iter()
-            .enumerate()
-            .find(|(index, _)| *index as u32 == item.tokens[0])
+            .find(|t| t.index == item.tokens[0])
             .context("base token index not found")?;
-        let (_, quote) = spot_tokens
+        let quote = spot_tokens
             .iter()
-            .enumerate()
-            .find(|(index, _)| *index as u32 == item.tokens[1])
+            .find(|t| t.index == item.tokens[1])
             .context("quote token index not found")?;
 
         markets.push(SpotMarket {


### PR DESCRIPTION
## Summary

  `hypercore::spot_markets()` resolves each universe market's base/quote token by its **position** in the `tokens` array instead of by the token's `index` field. This panics (`.expect`) / errors (`.context`) on current mainnet data, taking down every caller of `client.spot()`.

  ## Root cause

  ```rust
  spot_tokens.iter().enumerate()
      .find(|(pos, _)| *pos as u32 == item.tokens[0])   // matches ARRAY POSITION
      .expect("base");                                  // .context(...)? on newer versions
  ```

  A universe market references its tokens by their **`index` field** (`item.tokens = [baseIndex, quoteIndex]`). The lookup above instead compares the `enumerate()` **array position** to that index. These are equal only while the `tokens` array is dense and contiguous (index 0,1,2,… lining up with position).

  That held for a long time, so the position-based lookup happened to work. It is not inherent to the data: as HyperCore's spot set evolves (new listings + delistings), token indices become **sparse** — gaps appear and a token's `index` no longer equals its array position. The bug stayed latent until a market was listed whose referenced
  token index exceeds the array length.

  ## What triggers it today

  Mainnet spot market **`@367` (WARS/USDC)** references base token **index 479**, but the `tokens` array currently has **464** entries. The position-based lookup searches for array position 479 — which does not exist in a 464-element array — so `.find()` returns `None` and `spot_markets()` fails.

  The key fact: **token `index` != array position.** Token `WARS` has `index = 479` but lives at array **position 459**. The old code uses 479 as a position (out of range); it should use 479 to match the `index` field.

  ## Reproduce / verify (no SDK needed)

  ```bash
  curl -s -X POST https://api.hyperliquid.xyz/info \
    -H 'Content-Type: application/json' -d '{"type":"spotMeta"}' > sm.json

  # tokens array length            -> 464
  jq '.tokens | length' sm.json

  # market @367 references token... -> {"name":"@367","tokens":[479,0],"index":367}
  jq -c '.universe[] | select(.name=="@367") | {name, tokens, index}' sm.json

  # token with index 479           -> "WARS"
  jq -r '.tokens[] | select(.index==479) | .name' sm.json

  # its actual array position      -> 459   (NOT 479 — this is the bug)
  jq '[.tokens[].index] | index(479)' sm.json
  ```

  `@367.tokens[0] = 479` → old code looks up array position 479 → array is only 464 long → `None` → panic/error. The token actually lives at position 459 and is found correctly when matched by its `index` field.

  Equivalently, against the SDK: `spot_markets(mainnet_url, client)` fails on `@367`.

  Note this class of bug can also fail *silently*: for an index that is in range but shifted by an earlier gap, the position lookup returns the **wrong** token (one whose `index` != the requested value) with no error at all.

  ## Fix

  Match on the token's own `index` field — the value universe markets actually reference:

  ```rust
  let base = spot_tokens
      .iter()
      .find(|t| t.index == item.tokens[0])
      .context("base token index not found")?;
  let quote = spot_tokens
      .iter()
      .find(|t| t.index == item.tokens[1])
      .context("quote token index not found")?;
  ```

  Correct regardless of gaps: returns the token whose `index` equals the requested value, or a clear error if none exists. It can never return a token with a mismatched index.

  ## Verification

  `test_spot_markets` (mainnet) passes; it failed on `@367` before this change.