### PR TITLE
fix(hypercore): fix round_by_side rounding

### DIFF
--- a/src/hypercore/mod.rs
+++ b/src/hypercore/mod.rs
@@ -799,7 +799,7 @@ impl PriceTick {
                 RoundingStrategy::ToNegativeInfinity
             }
         };
-        let rounded = price.round_dp_with_strategy(tick.scale(), strategy);
+        let rounded = (price / tick).round_dp_with_strategy(0, strategy) * tick;
         Some(rounded)
     }
 }


### PR DESCRIPTION
`round` fn was already using the correct logic. Discovered on Hyperliquid testnet on ETH-USDC