### PR TITLE
Add fast option to Hyperliquid l2Book subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ async fn main() -> anyhow::Result<()> {
         coin: "ETH".into(),
         n_sig_figs: None,
         mantissa: None,
+        fast: None,
     });
 
     // Optional: user streams

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ async fn main() -> anyhow::Result<()> {
         coin: "ETH".into(),
         n_sig_figs: None,
         mantissa: None,
-        fast: None,
+        fast: false,
     });
 
     // Optional: user streams

--- a/examples/hypercore/websocket.rs
+++ b/examples/hypercore/websocket.rs
@@ -29,7 +29,7 @@
 //!
 //! - `AllMids`: Mid prices for all markets
 //! - `Trades { coin }`: Real-time trades for a specific coin
-//! - `L2Book { coin, n_sig_figs, mantissa }`: Order book updates with optional price-level aggregation
+//! - `L2Book { coin, n_sig_figs, mantissa, fast }`: Order book updates with optional price-level aggregation or fast 5-level mode
 //! - `UserEvents { user }`: User-specific events (fills, liquidations)
 
 use anyhow::Context;

--- a/hypecli/src/subscribe.rs
+++ b/hypecli/src/subscribe.rs
@@ -266,7 +266,7 @@ impl OrderbookCmd {
             coin: resolved.coin.clone(),
             n_sig_figs: None,
             mantissa: None,
-            fast: None,
+            fast: false,
         });
 
         eprintln!("Subscribing to {} orderbook...", self.asset);

--- a/hypecli/src/subscribe.rs
+++ b/hypecli/src/subscribe.rs
@@ -266,6 +266,7 @@ impl OrderbookCmd {
             coin: resolved.coin.clone(),
             n_sig_figs: None,
             mantissa: None,
+            fast: None,
         });
 
         eprintln!("Subscribing to {} orderbook...", self.asset);

--- a/src/hypercore/mod.rs
+++ b/src/hypercore/mod.rs
@@ -50,6 +50,7 @@
 //!     coin: "BTC".into(),
 //!     n_sig_figs: None,
 //!     mantissa: None,
+//!     fast: None,
 //! });
 //!
 //! while let Some(event) = ws.next().await {

--- a/src/hypercore/mod.rs
+++ b/src/hypercore/mod.rs
@@ -50,7 +50,7 @@
 //!     coin: "BTC".into(),
 //!     n_sig_figs: None,
 //!     mantissa: None,
-//!     fast: None,
+//!     fast: false,
 //! });
 //!
 //! while let Some(event) = ws.next().await {

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -364,6 +364,11 @@ pub enum Subscription {
         /// Further aggregation; only valid when `n_sig_figs` is `5` (values: 1, 2, or 5).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         mantissa: Option<u8>,
+        /// Opt into Hyperliquid's faster l2Book mode introduced with the websocket push-frequency
+        /// migration: `fast: true` pushes 5 levels roughly every 0.5s, while the default feed
+        /// remains the deeper, slower 20-level snapshot stream.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fast: Option<bool>,
     },
     /// Real-time candlestick updates
     #[display("candle({coin}@{interval})")]
@@ -4258,6 +4263,34 @@ mod tests {
         assert_eq!(json, serde_json::json!({ "type": "fastAssetCtxs" }));
         let deserialized: Subscription = serde_json::from_value(json).unwrap();
         assert_eq!(sub, deserialized);
+    }
+
+    #[test]
+    fn test_l2_book_fast_subscription() {
+        let slow = Subscription::L2Book {
+            coin: "BTC".to_string(),
+            n_sig_figs: None,
+            mantissa: None,
+            fast: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&slow).unwrap(),
+            serde_json::json!({ "type": "l2Book", "coin": "BTC" })
+        );
+
+        let fast = Subscription::L2Book {
+            coin: "BTC".to_string(),
+            n_sig_figs: None,
+            mantissa: None,
+            fast: Some(true),
+        };
+        let json = serde_json::to_value(&fast).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "type": "l2Book", "coin": "BTC", "fast": true })
+        );
+        let deserialized: Subscription = serde_json::from_value(json).unwrap();
+        assert_eq!(fast, deserialized);
     }
 
     #[test]

--- a/src/hypercore/types/mod.rs
+++ b/src/hypercore/types/mod.rs
@@ -367,8 +367,8 @@ pub enum Subscription {
         /// Opt into Hyperliquid's faster l2Book mode introduced with the websocket push-frequency
         /// migration: `fast: true` pushes 5 levels roughly every 0.5s, while the default feed
         /// remains the deeper, slower 20-level snapshot stream.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        fast: Option<bool>,
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        fast: bool,
     },
     /// Real-time candlestick updates
     #[display("candle({coin}@{interval})")]
@@ -4271,7 +4271,7 @@ mod tests {
             coin: "BTC".to_string(),
             n_sig_figs: None,
             mantissa: None,
-            fast: None,
+            fast: false,
         };
         assert_eq!(
             serde_json::to_value(&slow).unwrap(),
@@ -4282,7 +4282,7 @@ mod tests {
             coin: "BTC".to_string(),
             n_sig_figs: None,
             mantissa: None,
-            fast: Some(true),
+            fast: true,
         };
         let json = serde_json::to_value(&fast).unwrap();
         assert_eq!(

--- a/src/hypercore/ws.rs
+++ b/src/hypercore/ws.rs
@@ -60,7 +60,7 @@
 //!     coin: "BTC".into(),
 //!     n_sig_figs: None,
 //!     mantissa: None,
-//!     fast: None,
+//!     fast: false,
 //! });
 //!
 //! while let Some(event) = ws.next().await {
@@ -356,7 +356,7 @@ pub struct Connection {
 ///         coin: "ETH".into(),
 ///         n_sig_figs: None,
 ///         mantissa: None,
-///         fast: None,
+///         fast: false,
 ///     });
 ///
 ///     // Later, unsubscribe
@@ -467,7 +467,7 @@ impl Connection {
     ///
     /// Subscribe to market data:
     /// - `ws.subscribe(Subscription::Trades { coin: "BTC".into() })`
-    /// - `ws.subscribe(Subscription::L2Book { coin: "ETH".into(), n_sig_figs: None, mantissa: None, fast: None })`
+    /// - `ws.subscribe(Subscription::L2Book { coin: "ETH".into(), n_sig_figs: None, mantissa: None, fast: false })`
     pub fn subscribe(&self, subscription: Subscription) {
         let _ = self.tx.send((true, subscription));
     }
@@ -536,7 +536,7 @@ impl ConnectionHandle {
     ///
     /// Subscribe to market data:
     /// - `ws.subscribe(Subscription::Trades { coin: "BTC".into() })`
-    /// - `ws.subscribe(Subscription::L2Book { coin: "ETH".into(), n_sig_figs: None, mantissa: None, fast: None })`
+    /// - `ws.subscribe(Subscription::L2Book { coin: "ETH".into(), n_sig_figs: None, mantissa: None, fast: false })`
     pub fn subscribe(&self, subscription: Subscription) {
         let _ = self.tx.send((true, subscription));
     }

--- a/src/hypercore/ws.rs
+++ b/src/hypercore/ws.rs
@@ -60,6 +60,7 @@
 //!     coin: "BTC".into(),
 //!     n_sig_figs: None,
 //!     mantissa: None,
+//!     fast: None,
 //! });
 //!
 //! while let Some(event) = ws.next().await {
@@ -355,6 +356,7 @@ pub struct Connection {
 ///         coin: "ETH".into(),
 ///         n_sig_figs: None,
 ///         mantissa: None,
+///         fast: None,
 ///     });
 ///
 ///     // Later, unsubscribe
@@ -465,7 +467,7 @@ impl Connection {
     ///
     /// Subscribe to market data:
     /// - `ws.subscribe(Subscription::Trades { coin: "BTC".into() })`
-    /// - `ws.subscribe(Subscription::L2Book { coin: "ETH".into(), n_sig_figs: None, mantissa: None })`
+    /// - `ws.subscribe(Subscription::L2Book { coin: "ETH".into(), n_sig_figs: None, mantissa: None, fast: None })`
     pub fn subscribe(&self, subscription: Subscription) {
         let _ = self.tx.send((true, subscription));
     }
@@ -534,7 +536,7 @@ impl ConnectionHandle {
     ///
     /// Subscribe to market data:
     /// - `ws.subscribe(Subscription::Trades { coin: "BTC".into() })`
-    /// - `ws.subscribe(Subscription::L2Book { coin: "ETH".into(), n_sig_figs: None, mantissa: None })`
+    /// - `ws.subscribe(Subscription::L2Book { coin: "ETH".into(), n_sig_figs: None, mantissa: None, fast: None })`
     pub fn subscribe(&self, subscription: Subscription) {
         let _ = self.tx.send((true, subscription));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@
 //!     coin: "ETH".into(),
 //!     n_sig_figs: None,
 //!     mantissa: None,
+//!     fast: None,
 //! });
 //! ws.subscribe(Subscription::Candle {
 //!     coin: "BTC".into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //!     coin: "ETH".into(),
 //!     n_sig_figs: None,
 //!     mantissa: None,
-//!     fast: None,
+//!     fast: false,
 //! });
 //! ws.subscribe(Subscription::Candle {
 //!     coin: "BTC".into(),


### PR DESCRIPTION
  On June 9th 2026.  Hyperliquid announced a websocket push-frequency migration for l2Book:
  the default l2Book subscription remains the deeper 20-level snapshot feed,
  while clients can opt into `fast: true` to receive a 5-level book at a
  higher cadence(0.5s).

  The Rust SDK did not expose the new `fast` subscription field, forcing
  clients to bypass the typed API or hand-roll subscription JSON.

  Add `fast: Option<bool>` to `Subscription::L2Book`, keep it omitted by
  default, update examples/docs/CLI call sites, and add a serialization
  round-trip test for both default and fast l2Book subscriptions.

  Docs: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions