### PR TITLE
Fix EvmUserModify failing to be deserialized on Hyperliquid API

### DIFF
--- a/src/hypercore/types/api.rs
+++ b/src/hypercore/types/api.rs
@@ -36,9 +36,11 @@ pub struct ActionRequest {
     pub nonce: u64,
     /// Signature
     pub signature: Signature,
-    /// Trading on behalf of
+    /// Trading on behalf of — omitted from JSON when None (server rejects null)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub vault_address: Option<Address>,
-    /// Timestamp in milliseconds
+    /// Timestamp in milliseconds — omitted from JSON when None (server rejects null)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_after: Option<u64>,
 }
 
@@ -85,6 +87,10 @@ pub enum Action {
     SpotSend(SpotSendAction),
     /// EVM user modify.
     EvmUserModify {
+        // rename_all = "camelCase" on the enum applies to variant names but not
+        // struct variant fields when using #[serde(tag = "type")]. Explicit rename
+        // fixes both the JSON body and the msgpack signing hash.
+        #[serde(rename = "usingBigBlocks")]
         using_big_blocks: bool,
     },
     ApproveAgent(ApproveAgent),

--- a/src/hypercore/types/api.rs
+++ b/src/hypercore/types/api.rs
@@ -36,11 +36,9 @@ pub struct ActionRequest {
     pub nonce: u64,
     /// Signature
     pub signature: Signature,
-    /// Trading on behalf of — omitted from JSON when None (server rejects null)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Trading on behalf of
     pub vault_address: Option<Address>,
-    /// Timestamp in milliseconds — omitted from JSON when None (server rejects null)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Timestamp in milliseconds
     pub expires_after: Option<u64>,
 }
 


### PR DESCRIPTION
See #70 for full explanation, but camelCase doesn't apply to struct variant fields in certain circumstances, causing a 422 when sending EvmUserModify to the HL API. 