### PR TITLE
feat(hypecli): add HIP-4 outcome commands

### DIFF
--- a/hypecli/src/main.rs
+++ b/hypecli/src/main.rs
@@ -5,6 +5,7 @@ mod morpho;
 mod multisig;
 mod orders;
 mod orders_list;
+mod outcome;
 mod positions;
 mod prio;
 mod send;
@@ -23,6 +24,7 @@ use morpho::{MorphoApyCmd, MorphoPositionCmd, MorphoVaultApyCmd};
 use multisig::MultiSigCmd;
 use orders::OrderCmd;
 use orders_list::OrdersCmd;
+use outcome::OutcomeCmd;
 use positions::PositionsCmd;
 use prio::PrioCmd;
 use send::SendCmd;
@@ -72,6 +74,9 @@ enum Command {
     /// Order management (place and cancel orders)
     #[command(subcommand)]
     Order(OrderCmd),
+    /// HIP-4 outcome token operations (split, merge, negate)
+    #[command(subcommand)]
+    Outcome(OutcomeCmd),
     /// Subscribe to real-time WebSocket data feeds
     #[command(subcommand)]
     Subscribe(SubscribeCmd),
@@ -106,6 +111,7 @@ impl Command {
             Self::Multisig(cmd) => cmd.run().await,
             Self::ToMultisig(cmd) => cmd.run().await,
             Self::Order(cmd) => cmd.run().await,
+            Self::Outcome(cmd) => cmd.run().await,
             Self::Subscribe(cmd) => cmd.run().await,
             Self::Send(cmd) => cmd.run().await,
             Self::Vault(cmd) => cmd.run().await,
@@ -123,7 +129,8 @@ impl Command {
 /// the signer credentials and target multi-sig wallet.
 #[derive(Args)]
 pub struct SignerArgs {
-    /// Private key for signing (hex format).
+    /// Private key for signing (hex format). Agent (API wallet) keys work
+    /// for L1 actions such as orders and outcome operations.
     #[arg(long)]
     pub private_key: Option<String>,
     /// Foundry keystore.
@@ -182,6 +189,10 @@ Commands that modify state (orders, transfers, etc.) require authentication via 
 
 Note: Ledger and Trezor hardware wallets are supported for multi-sig operations but NOT for
 order placement/cancellation (which require synchronous signing).
+
+Agent (API wallet) private keys are accepted for L1 actions (orders, TWAP, vault transfers,
+outcome operations); the exchange attributes the action to the master account. User-signed
+actions (sends, approvals) still require the master key.
 
 ASSET NAME FORMATS
 ------------------
@@ -343,6 +354,53 @@ Cancel Order (by OID or CLOID):
     --asset <NAME>    Asset name the order belongs to
     --oid <NUMBER>    Exchange-assigned order ID (use this OR --cloid)
     --cloid <HEX>     Client-assigned order ID, 32 hex chars (use this OR --oid)
+
+OUTCOME COMMANDS (HIP-4)
+------------------------
+
+Outcome markets are fully collateralized binary contracts. The quote token can be
+split into one share of each side of an outcome, and matching shares can be merged
+back. Outcome and question IDs come from `hypecli outcome list`.
+
+List Outcomes and Questions:
+  hypecli outcome list
+  hypecli outcome list --chain testnet
+
+Split Quote Token into Outcome Shares:
+  hypecli outcome split \
+    --chain mainnet \
+    --private-key <HEX> \
+    --outcome 12 \
+    --amount 100
+
+Merge Outcome Shares Back into the Quote Token:
+  hypecli outcome merge \
+    --chain mainnet \
+    --private-key <HEX> \
+    --outcome 12 \
+    --amount 100
+
+  Omit --amount to merge the maximum available.
+
+Merge a Question's Full Outcome Set:
+  hypecli outcome merge-question \
+    --chain mainnet \
+    --private-key <HEX> \
+    --question 3
+
+  Merges a full set of mutually-exclusive outcomes within a question back into
+  the quote token. Omit --amount to merge the maximum available.
+
+Negate an Outcome within a Question:
+  hypecli outcome negate \
+    --chain mainnet \
+    --private-key <HEX> \
+    --question 3 \
+    --outcome 12 \
+    --amount 50
+
+  Converts shares of one outcome into the complementary basket (the "No" of
+  that outcome) within a categorical question.
 
 MULTI-SIG COMMANDS
 ------------------

--- a/hypecli/src/outcome.rs
+++ b/hypecli/src/outcome.rs
@@ -1,0 +1,254 @@
+//! HIP-4 outcome token commands.
+//!
+//! This module provides commands for splitting, merging, and negating
+//! outcome tokens, plus a listing command to discover outcome and
+//! question IDs from the `outcomeMeta` info endpoint.
+
+use std::io::{Write, stdout};
+
+use clap::{Args, Subcommand};
+use hypersdk::{
+    Decimal,
+    hypercore::{Chain, HttpClient, NonceHandler},
+};
+
+use crate::SignerArgs;
+use crate::utils::find_signer_sync;
+
+/// HIP-4 outcome token commands.
+#[derive(Subcommand)]
+pub enum OutcomeCmd {
+    /// List outcome markets and questions with their IDs
+    List(OutcomeListCmd),
+    /// Split the quote token into one share of each side of an outcome
+    Split(OutcomeSplitCmd),
+    /// Merge matching shares of an outcome back into the quote token
+    Merge(OutcomeMergeCmd),
+    /// Merge a full set of outcomes within a question back into the quote token
+    MergeQuestion(OutcomeMergeQuestionCmd),
+    /// Convert shares of an outcome into the complementary basket within a question
+    Negate(OutcomeNegateCmd),
+}
+
+impl OutcomeCmd {
+    pub async fn run(self) -> anyhow::Result<()> {
+        match self {
+            OutcomeCmd::List(cmd) => cmd.run().await,
+            OutcomeCmd::Split(cmd) => cmd.run().await,
+            OutcomeCmd::Merge(cmd) => cmd.run().await,
+            OutcomeCmd::MergeQuestion(cmd) => cmd.run().await,
+            OutcomeCmd::Negate(cmd) => cmd.run().await,
+        }
+    }
+}
+
+/// Arguments for the outcome listing query.
+#[derive(Args)]
+pub struct OutcomeListCmd {
+    /// Chain to query.
+    #[arg(long, default_value = "mainnet")]
+    pub chain: Chain,
+}
+
+impl OutcomeListCmd {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let client = HttpClient::new(self.chain);
+        let meta = client.outcome_meta().await?;
+
+        let mut writer = tabwriter::TabWriter::new(stdout());
+
+        let _ = writeln!(&mut writer, "outcome\tname\tsides\tdescription");
+        for outcome in &meta.outcomes {
+            let sides = outcome
+                .side_specs
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect::<Vec<_>>()
+                .join("/");
+            let _ = writeln!(
+                &mut writer,
+                "{}\t{}\t{}\t{}",
+                outcome.outcome, outcome.name, sides, outcome.description,
+            );
+        }
+
+        let _ = writeln!(&mut writer);
+        let _ = writeln!(
+            &mut writer,
+            "question\tname\toutcomes\tsettled\tfallback\tdescription"
+        );
+        for question in &meta.questions {
+            let ids = |ids: &[u32]| {
+                ids.iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            };
+            let fallback = question
+                .fallback_outcome
+                .map(|o| o.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let _ = writeln!(
+                &mut writer,
+                "{}\t{}\t{}\t{}\t{}\t{}",
+                question.question,
+                question.name,
+                ids(&question.named_outcomes),
+                ids(&question.settled_named_outcomes),
+                fallback,
+                question.description,
+            );
+        }
+
+        let _ = writer.flush();
+
+        Ok(())
+    }
+}
+
+/// Arguments for splitting the quote token into outcome shares.
+#[derive(Args, derive_more::Deref)]
+pub struct OutcomeSplitCmd {
+    #[deref]
+    #[command(flatten)]
+    pub signer: SignerArgs,
+
+    /// Outcome ID (see `hypecli outcome list`)
+    #[arg(long)]
+    pub outcome: u32,
+
+    /// Amount of the quote token to split
+    #[arg(long)]
+    pub amount: Decimal,
+}
+
+impl OutcomeSplitCmd {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let signer = find_signer_sync(&self.signer)?;
+        let client = HttpClient::new(self.signer.chain);
+        let nonce = NonceHandler::default().next();
+        println!(
+            "Splitting {} of the quote token into outcome {}",
+            self.amount, self.outcome
+        );
+        client
+            .split_outcome(&signer, self.outcome, self.amount, nonce, None, None)
+            .await?;
+        println!("Split successfully.");
+        Ok(())
+    }
+}
+
+/// Arguments for merging outcome shares back into the quote token.
+#[derive(Args, derive_more::Deref)]
+pub struct OutcomeMergeCmd {
+    #[deref]
+    #[command(flatten)]
+    pub signer: SignerArgs,
+
+    /// Outcome ID (see `hypecli outcome list`)
+    #[arg(long)]
+    pub outcome: u32,
+
+    /// Amount of matching shares to merge. Omit to merge the maximum available.
+    #[arg(long)]
+    pub amount: Option<Decimal>,
+}
+
+impl OutcomeMergeCmd {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let signer = find_signer_sync(&self.signer)?;
+        let client = HttpClient::new(self.signer.chain);
+        let nonce = NonceHandler::default().next();
+        match self.amount {
+            Some(amount) => println!("Merging {} shares of outcome {}", amount, self.outcome),
+            None => println!("Merging all available shares of outcome {}", self.outcome),
+        }
+        client
+            .merge_outcome(&signer, self.outcome, self.amount, nonce, None, None)
+            .await?;
+        println!("Merged successfully.");
+        Ok(())
+    }
+}
+
+/// Arguments for merging a question's full outcome set back into the quote token.
+#[derive(Args, derive_more::Deref)]
+pub struct OutcomeMergeQuestionCmd {
+    #[deref]
+    #[command(flatten)]
+    pub signer: SignerArgs,
+
+    /// Question ID (see `hypecli outcome list`)
+    #[arg(long)]
+    pub question: u32,
+
+    /// Amount to merge. Omit to merge the maximum available.
+    #[arg(long)]
+    pub amount: Option<Decimal>,
+}
+
+impl OutcomeMergeQuestionCmd {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let signer = find_signer_sync(&self.signer)?;
+        let client = HttpClient::new(self.signer.chain);
+        let nonce = NonceHandler::default().next();
+        match self.amount {
+            Some(amount) => println!("Merging {} across question {}", amount, self.question),
+            None => println!(
+                "Merging all available outcome sets of question {}",
+                self.question
+            ),
+        }
+        client
+            .merge_outcome_question(&signer, self.question, self.amount, nonce, None, None)
+            .await?;
+        println!("Merged successfully.");
+        Ok(())
+    }
+}
+
+/// Arguments for negating an outcome within a question.
+#[derive(Args, derive_more::Deref)]
+pub struct OutcomeNegateCmd {
+    #[deref]
+    #[command(flatten)]
+    pub signer: SignerArgs,
+
+    /// Question ID (see `hypecli outcome list`)
+    #[arg(long)]
+    pub question: u32,
+
+    /// Outcome ID to negate within the question
+    #[arg(long)]
+    pub outcome: u32,
+
+    /// Amount of shares to negate
+    #[arg(long)]
+    pub amount: Decimal,
+}
+
+impl OutcomeNegateCmd {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let signer = find_signer_sync(&self.signer)?;
+        let client = HttpClient::new(self.signer.chain);
+        let nonce = NonceHandler::default().next();
+        println!(
+            "Negating {} shares of outcome {} within question {}",
+            self.amount, self.outcome, self.question
+        );
+        client
+            .negate_outcome(
+                &signer,
+                self.question,
+                self.outcome,
+                self.amount,
+                nonce,
+                None,
+                None,
+            )
+            .await?;
+        println!("Negated successfully.");
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds a new `hypecli outcome` command group for HIP-4 outcome tokens:

- `outcome list [--chain]`: prints outcomes (ID, name, sides, description) and questions (ID, name, outcome IDs, settled IDs, fallback) from the `outcomeMeta` info endpoint, so users can discover the integer IDs the write commands need.
- `outcome split --outcome --amount`: split the quote token into one share of each side.
- `outcome merge --outcome [--amount]`: merge matching shares back into the quote token; omitting `--amount` merges the maximum available.
- `outcome merge-question --question [--amount]`: merge a full set of mutually-exclusive outcomes within a question.
- `outcome negate --question --outcome --amount`: convert shares of one outcome into the complementary basket.

Write commands reuse the shared `SignerArgs` and follow the `vault.rs` pattern (`find_signer_sync` + `HttpClient` + `NonceHandler`), passing `None` for `vault_address`/`expires_after` like the other write commands. Since `userOutcome` is an L1 agent-signed action, agent (API wallet) keys work out of the box; this is now documented in `--agent-help` and the `--private-key` flag help.

Verified: clean build, no new clippy warnings, help output for all subcommands, and `outcome list` against live mainnet and testnet. Write paths are thin wrappers over the SDK methods exercised by `examples/hypercore/split_merge_outcome.rs`; not yet exercised with a funded key from the CLI.